### PR TITLE
Reject negative bigint hexlify values

### DIFF
--- a/src/sdk/common/utils/hexlify.ts
+++ b/src/sdk/common/utils/hexlify.ts
@@ -91,6 +91,10 @@ export function hexlifyValue(value: BytesLike | Hexable | number | bigint, optio
     }
 
     if (typeof (value) === "bigint") {
+        if (value < 0n) {
+            throw new Error(`Invalid Hexlify value - negative bigint value: ${value}`);
+        }
+
         value = value.toString(16);
         if (value.length % 2) { return ("0x0" + value); }
         return "0x" + value;

--- a/test/hexlify.test.ts
+++ b/test/hexlify.test.ts
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import { hexlifyValue } from '../src/sdk/common/utils/hexlify.js';
+
+assert.equal(hexlifyValue(0n), '0x00');
+assert.equal(hexlifyValue(15n), '0x0f');
+assert.equal(hexlifyValue(16n), '0x10');
+assert.throws(() => hexlifyValue(-1n), /negative bigint value/);
+assert.throws(() => hexlifyValue(-16n), /negative bigint value/);


### PR DESCRIPTION
Negative bigint values currently produce malformed hex strings like `0x-1` or `0x0-10` in `hexlifyValue`.

This rejects negative bigint inputs before conversion, matching the existing unsigned checks for number inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject invalid inputs during hexadecimal conversion operations.

* **Tests**
  * Added comprehensive test coverage for hexadecimal conversion functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->